### PR TITLE
Fix Stroke order buttons not working after refactoring

### DIFF
--- a/addon/card_type.py
+++ b/addon/card_type.py
@@ -131,6 +131,7 @@ class CardTypeData(metaclass=CardTypeDataMeta):
         dmak_js = "<script>" + read_web_file("dmak.js") + "</script>\n\n"
         raphael_js = "<script>" + read_web_file("raphael.js") + "</script>\n\n"
         japanese_util_js = "<script>" + read_web_file("japanese-util.js") + "</script>\n\n"
+        launch_back_js = f"<script>render_page('{self.label}');</script>"
 
         # Set template html
         template["qfmt"] = (
@@ -143,8 +144,9 @@ class CardTypeData(metaclass=CardTypeDataMeta):
             dmak_js +
             raphael_js +
             japanese_util_js +
+            read_web_file_with_includes(f"back-{self.label}.html") +
             common_back_js +
-            read_web_file_with_includes(f"back-{self.label}.html")
+            launch_back_js
         )
 
         aqt.mw.col.models.save(model)

--- a/addon/lookup_window.py
+++ b/addon/lookup_window.py
@@ -137,8 +137,8 @@ class LookupWindow(QDialog):
             + style_class
             + '">'
             + settings_html
-            + common_back
             + body_html
+            + common_back
             + set_keys_html
             + "</body></html>"
         )

--- a/addon/web/back-production.html
+++ b/addon/web/back-production.html
@@ -166,8 +166,6 @@ START - Migaku markup
 <!-- START - Addon script, Production, back -->
 <script>
 	var kanjivg_uri = 'kanji_';
-
-	render_page("production");
 </script>
 <!-- END - Addon script, Production, back -->
 

--- a/addon/web/back-recognition.html
+++ b/addon/web/back-recognition.html
@@ -162,8 +162,6 @@ START - Migaku markup
 <!-- START - Addon script, Recognition, back -->
 <script>
 	var kanjivg_uri = 'kanji_';
-
-	render_page("recognition");
 </script>
 <!-- END - Addon script, Recognition, back -->
 


### PR DESCRIPTION
Elements have to be in correct order (first HTML, then common JavaScript) followed by page rendering. Otherwise Stroke Order buttons aren't initialized properly.