### PR TITLE
fix: changed question buttons to use StandardButton

### DIFF
--- a/addon/card_layout.py
+++ b/addon/card_layout.py
@@ -20,8 +20,8 @@ def CardLayout_init_hook(self, mw: AnkiQt, note: Note, *args, **kwargs):
                 "You are able to edit the template for the note type by editing the corresponding HTML and CSS files inside the add-on directory.\n\n"
                 "Do you want to open that directory now?\n\n"
                 "Note: If you edit the templates be aware that updates to the add-on will overwrite those files.",
-                QMessageBox.StandardButton.Yes | QMessageBox.No,
-                QMessageBox.No,
+                QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+                QMessageBox.StandardButton.No,
             )
             if r == QMessageBox.StandardButton.Yes:
                 aqt.utils.openFolder(util.addon_path("web"))

--- a/addon/settings_window.py
+++ b/addon/settings_window.py
@@ -203,8 +203,8 @@ class CardTypeSettingsWidget(QWidget):
             "Migaku Kanji",
             f"Do you really want to reset kanji marked known for {self.card_type.label}?<br><br>"
             "<b>They will not be recoverable.</b>",
-            QMessageBox.StandardButton.Yes | QMessageBox.No,
-            QMessageBox.No,
+            QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+            QMessageBox.StandardButton.No,
         )
         if r != QMessageBox.StandardButton.Yes:
             return
@@ -456,8 +456,8 @@ class SettingsWindow(QDialog):
             "Do you really want to reset the Migaku Kanji Database?<br><br>"
             "<b>All kanji manually marked known, custom stories and keywords will be lost!</b><br><br>"
             "Kanji cards and their progress will remain.",
-            QMessageBox.StandardButton.Yes | QMessageBox.No,
-            QMessageBox.No,
+            QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+            QMessageBox.StandardButton.No,
         )
         if r != QMessageBox.StandardButton.Yes:
             return
@@ -472,8 +472,8 @@ class SettingsWindow(QDialog):
             "Migaku Kanji",
             "Do you really want to reset all custom keywords?<br><br>"
             "<b>They will not be recoverable.</b>",
-            QMessageBox.StandardButton.Yes | QMessageBox.No,
-            QMessageBox.No,
+            QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+            QMessageBox.StandardButton.No,
         )
         if r != QMessageBox.StandardButton.Yes:
             return
@@ -486,8 +486,8 @@ class SettingsWindow(QDialog):
             "Migaku Kanji",
             "Do you really want to reset all custom stories?<br><br>"
             "<b>They will not be recoverable.</b>",
-            QMessageBox.StandardButton.Yes | QMessageBox.No,
-            QMessageBox.No,
+            QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+            QMessageBox.StandardButton.No,
         )
         if r != QMessageBox.StandardButton.Yes:
             return


### PR DESCRIPTION
Some users may experience `AttributeError: type object 'QMessageBox' has no attribute 'No'` when trying to open any `QmessageBox.question` with Yes/No answers like `reset_db`.
Using `StantardButton` instead of `No` directly fixes this problem.
[Discord thread with this problem](https://discord.com/channels/752293144917180496/1204756246528532531)