### PR TITLE
Fix SQL query for fetching new learn ahead kanji

### DIFF
--- a/addon/kanji.py
+++ b/addon/kanji.py
@@ -449,7 +449,7 @@ class KanjiDB:
     # checks learn ahead for a given deck
     def new_learn_ahead_kanji(self, card_type, deck_id, max_cards):
         nids = aqt.mw.col.db.all(
-            f"SELECT c.nid FROM cards as c WHERE did={deck_id} AND type=0 ORDER BY c.due AND queue>=0 LIMIT {max_cards}"
+            f"SELECT c.nid FROM cards as c WHERE did={deck_id} AND type=0 AND queue>=0 ORDER BY c.due LIMIT {max_cards}"
         )
 
         kanji_seen = set()


### PR DESCRIPTION
When doing lookahead, the query `ORDER BY` was broken due to the `AND`, so it essentially returned cards in arbitrary order. That was mostly fine since it seemed like it was accurate upon deck import, but it broke if due order was changed.

This simply fixes the query by rearranging the terms. 